### PR TITLE
Feature: After Order completed (from IoT queue), send message to FE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,10 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/ca/uwaterloo/drinkmasterapi/config/WebSocketConfig.java
+++ b/src/main/java/ca/uwaterloo/drinkmasterapi/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package ca.uwaterloo.drinkmasterapi.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic");
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/websocket").withSockJS();
+    }
+}

--- a/src/main/java/ca/uwaterloo/drinkmasterapi/feature/order/event/OrderCompletionEvent.java
+++ b/src/main/java/ca/uwaterloo/drinkmasterapi/feature/order/event/OrderCompletionEvent.java
@@ -1,0 +1,21 @@
+package ca.uwaterloo.drinkmasterapi.feature.order.event;
+import org.springframework.context.ApplicationEvent;
+
+public class OrderCompletionEvent extends ApplicationEvent {
+    private final Long orderId;
+    private final boolean isCompleted;
+
+    public OrderCompletionEvent(Object source, Long orderId, boolean isCompleted) {
+        super(source);
+        this.orderId = orderId;
+        this.isCompleted = isCompleted;
+    }
+
+    public Long getOrderId() {
+        return orderId;
+    }
+
+    public boolean isCompleted() {
+        return isCompleted;
+    }
+}

--- a/src/main/java/ca/uwaterloo/drinkmasterapi/feature/order/event/PourDrinkEvent.java
+++ b/src/main/java/ca/uwaterloo/drinkmasterapi/feature/order/event/PourDrinkEvent.java
@@ -1,0 +1,45 @@
+package ca.uwaterloo.drinkmasterapi.feature.order.event;
+
+import ca.uwaterloo.drinkmasterapi.feature.order.dto.PourItemDTO;
+import org.springframework.context.ApplicationEvent;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class PourDrinkEvent extends ApplicationEvent {
+    private final Long orderId;
+    private final Long machineId;
+    private final Long transId;
+    private final LocalDateTime orderTime;
+    private final List<PourItemDTO> pourItems;
+
+    public PourDrinkEvent(Object source, Long orderId, Long machineId, Long transId, LocalDateTime orderTime, List<PourItemDTO> pourItems) {
+        super(source);
+        this.orderId = orderId;
+        this.machineId = machineId;
+        this.transId = transId;
+        this.orderTime = orderTime;
+        this.pourItems = pourItems;
+    }
+
+    // Getters
+    public Long getOrderId() {
+        return orderId;
+    }
+
+    public Long getMachineId() {
+        return machineId;
+    }
+
+    public Long getTransId() {
+        return transId;
+    }
+
+    public LocalDateTime getOrderTime() {
+        return orderTime;
+    }
+
+    public List<PourItemDTO> getPourItems() {
+        return pourItems;
+    }
+}

--- a/src/main/java/ca/uwaterloo/drinkmasterapi/feature/order/service/IMqttClientServiceImpl.java
+++ b/src/main/java/ca/uwaterloo/drinkmasterapi/feature/order/service/IMqttClientServiceImpl.java
@@ -2,22 +2,24 @@ package ca.uwaterloo.drinkmasterapi.feature.order.service;
 
 import ca.uwaterloo.drinkmasterapi.common.MqttTopic;
 import ca.uwaterloo.drinkmasterapi.feature.order.dto.PourItemDTO;
+import ca.uwaterloo.drinkmasterapi.feature.order.event.OrderCompletionEvent;
+import ca.uwaterloo.drinkmasterapi.feature.order.event.PourDrinkEvent;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.iot.client.AWSIotException;
-import com.amazonaws.services.iot.client.AWSIotMessage;
-import com.amazonaws.services.iot.client.AWSIotMqttClient;
-import com.amazonaws.services.iot.client.AWSIotQos;
+import com.amazonaws.services.iot.client.*;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.amazonaws.services.securitytoken.model.Credentials;
 import com.amazonaws.services.securitytoken.model.GetSessionTokenRequest;
 import com.amazonaws.services.securitytoken.model.GetSessionTokenResult;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -26,14 +28,30 @@ import java.util.List;
 @Service
 public class IMqttClientServiceImpl implements IMqttClientService {
     private final AWSIotMqttClient awsIotMqttClient;
+    private final ApplicationEventPublisher eventPublisher;
 
     public IMqttClientServiceImpl(@Value("${awsiot.clientEndpoint}") String clientEndpoint,
                                   @Value("${awsiot.clientId}") String clientId,
                                   @Value("${awsiot.accessKey}") String accessKey,
                                   @Value("${awsiot.secretKey}") String secretKey,
-                                  @Value("${awsiot.region}") String region) throws AWSIotException {
-
+                                  @Value("${awsiot.region}") String region,
+                                  ApplicationEventPublisher eventPublisher) throws AWSIotException {
         this.awsIotMqttClient = initMqttClient(clientEndpoint, clientId, accessKey, secretKey, region);
+        subscribeToTopic(constructTopicPath(1L, MqttTopic.COMPLETE_TOPIC.getTopic()));
+        this.eventPublisher = eventPublisher;
+    }
+
+    @EventListener
+    public void onPourDrinkEvent(PourDrinkEvent event) {
+        try {
+            publishPourMessage(event.getOrderId(),
+                    event.getMachineId(),
+                    event.getTransId(),
+                    event.getOrderTime(),
+                    event.getPourItems());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to publish pour message", e);
+        }
     }
 
     @Override
@@ -45,10 +63,39 @@ public class IMqttClientServiceImpl implements IMqttClientService {
         pourObject.put("id", id);
         pourObject.put("transId", transId);
         pourObject.put("time", time.toString());
-        pourObject.put("content", contentArray);
+        pourObject.set("content", contentArray);
 
         AWSIotMessage pub = new AWSIotMessage(constructTopicPath(machineId, MqttTopic.POUR_TOPIC.getTopic()), AWSIotQos.QOS1, pourObject.toString());
         this.awsIotMqttClient.publish(pub);
+    }
+
+    private void processMessage(AWSIotMessage message) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode jsonNode = objectMapper.readTree(message.getStringPayload());
+            Long orderId = jsonNode.get("transId").asLong();
+            boolean isCompleted = jsonNode.get("val").asBoolean();
+
+            OrderCompletionEvent completionEvent = new OrderCompletionEvent(this, orderId, isCompleted);
+            eventPublisher.publishEvent(completionEvent);
+        } catch (Exception e) {
+            e.printStackTrace();
+            // Handle message processing error
+        }
+    }
+
+    private void subscribeToTopic(String topic) throws AWSIotException {
+        try {
+            awsIotMqttClient.subscribe(new AWSIotTopic(topic, AWSIotQos.QOS0) {
+                @Override
+                public void onMessage(AWSIotMessage message) {
+                    // This method is called whenever a message is received on the subscribed topic
+                    processMessage(message);
+                }
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     private AWSIotMqttClient initMqttClient(String clientEndpoint, String clientId, String accessKey, String secretKey, String region) throws AWSIotException {

--- a/src/main/java/ca/uwaterloo/drinkmasterapi/feature/order/service/IMqttClientServiceImpl.java
+++ b/src/main/java/ca/uwaterloo/drinkmasterapi/feature/order/service/IMqttClientServiceImpl.java
@@ -84,7 +84,7 @@ public class IMqttClientServiceImpl implements IMqttClientService {
         }
     }
 
-    private void subscribeToTopic(String topic) throws AWSIotException {
+    private void subscribeToTopic(String topic) {
         try {
             awsIotMqttClient.subscribe(new AWSIotTopic(topic, AWSIotQos.QOS0) {
                 @Override

--- a/src/main/java/ca/uwaterloo/drinkmasterapi/feature/order/service/IOrderService.java
+++ b/src/main/java/ca/uwaterloo/drinkmasterapi/feature/order/service/IOrderService.java
@@ -9,4 +9,6 @@ public interface IOrderService {
     OrderResponseDTO createOrder(OrderRequestDTO orderRequest);
 
     List<OrderResponseDTO> getOrderByUserId(Long userId);
+
+    void updateOrderStatus(Long orderId, boolean isCompleted);
 }

--- a/src/main/java/ca/uwaterloo/drinkmasterapi/feature/order/service/OrderServiceImpl.java
+++ b/src/main/java/ca/uwaterloo/drinkmasterapi/feature/order/service/OrderServiceImpl.java
@@ -95,12 +95,14 @@ public class OrderServiceImpl implements IOrderService {
             eventPublisher.publishEvent(pourMessageEvent);
         } catch (Exception e) {
             order.setStatus(OrderStatusEnum.CANCELED);
+            order.setModifiedAt(LocalDateTime.now().withNano(0));
             orderRepository.save(order);
             throw new OrderFailedException("Order failed due to some internal error, please contact administrator.");
         }
 
         ingredientRepository.saveAll(ingredients);
         order.setStatus(OrderStatusEnum.PENDING);
+        order.setModifiedAt(LocalDateTime.now().withNano(0));
         Order pendingOrder = orderRepository.save(order);
         return new OrderResponseDTO(pendingOrder);
     }
@@ -125,6 +127,7 @@ public class OrderServiceImpl implements IOrderService {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new RuntimeException("Order not found with ID: " + orderId));
         order.setStatus(isCompleted ? OrderStatusEnum.COMPLETED : OrderStatusEnum.CANCELED);
+        order.setModifiedAt(LocalDateTime.now().withNano(0));
         Order updatedOrder = orderRepository.save(order);
 
         // notify frontend

--- a/src/main/java/ca/uwaterloo/drinkmasterapi/feature/order/service/OrderServiceImpl.java
+++ b/src/main/java/ca/uwaterloo/drinkmasterapi/feature/order/service/OrderServiceImpl.java
@@ -132,7 +132,7 @@ public class OrderServiceImpl implements IOrderService {
 
         // notify frontend
         OrderResponseDTO responseDTO = new OrderResponseDTO(updatedOrder);
-        messagingTemplate.convertAndSend("/topic/order-status", responseDTO);
+        messagingTemplate.convertAndSend("/topic/order-complete", responseDTO);
     }
 
     private List<Ingredient> updateIngredientInventory(List<DrinkIngredient> drinkIngredients) throws InvalidCredentialsException {

--- a/src/test/java/ca/uwaterloo/drinkmasterapi/feature/order/OrderServiceImplTest.java
+++ b/src/test/java/ca/uwaterloo/drinkmasterapi/feature/order/OrderServiceImplTest.java
@@ -1,13 +1,9 @@
 package ca.uwaterloo.drinkmasterapi.feature.order;
 
-import ca.uwaterloo.drinkmasterapi.common.OrderStatusEnum;
-import ca.uwaterloo.drinkmasterapi.handler.exception.DataAlreadyUpdatedException;
 import ca.uwaterloo.drinkmasterapi.handler.exception.ResourceNotFoundException;
 import ca.uwaterloo.drinkmasterapi.dao.Drink;
 import ca.uwaterloo.drinkmasterapi.dao.Order;
 import ca.uwaterloo.drinkmasterapi.repository.DrinkRepository;
-import ca.uwaterloo.drinkmasterapi.dao.Machine;
-import ca.uwaterloo.drinkmasterapi.repository.MachineRepository;
 import ca.uwaterloo.drinkmasterapi.feature.order.dto.*;
 import ca.uwaterloo.drinkmasterapi.repository.OrderRepository;
 import ca.uwaterloo.drinkmasterapi.feature.order.service.OrderServiceImpl;
@@ -41,9 +37,6 @@ public class OrderServiceImplTest {
     @Mock
     private DrinkRepository drinkRepository;
 
-    @Mock
-    private MachineRepository machineRepository;
-
     @InjectMocks
     private OrderServiceImpl orderService;
 
@@ -53,14 +46,12 @@ public class OrderServiceImplTest {
         OrderRequestDTO orderRequest = new OrderRequestDTO();
         orderRequest.setUserId(1L);
         orderRequest.setDrinkId(2L);
-        orderRequest.setMachineId(3L);
 
         Order savedOrder = new Order();
         savedOrder.setId(4L);
 
         when(userRepository.findById(anyLong())).thenReturn(Optional.of(new User()));
         when(drinkRepository.findById(anyLong())).thenReturn(Optional.of(new Drink()));
-        when(machineRepository.findById(anyLong())).thenReturn(Optional.of(new Machine()));
         when(orderRepository.save(any(Order.class))).thenReturn(savedOrder);
 
         // Act
@@ -79,7 +70,6 @@ public class OrderServiceImplTest {
         OrderRequestDTO orderRequest = new OrderRequestDTO();
         orderRequest.setUserId(invalidUserId);
         orderRequest.setDrinkId(2L);
-        orderRequest.setMachineId(3L);
 
         when(userRepository.findById(invalidUserId)).thenReturn(Optional.empty());
 
@@ -95,7 +85,6 @@ public class OrderServiceImplTest {
         OrderRequestDTO orderRequest = new OrderRequestDTO();
         orderRequest.setUserId(1L);
         orderRequest.setDrinkId(invalidDrinkId);
-        orderRequest.setMachineId(3L);
 
         when(userRepository.findById(anyLong())).thenReturn(Optional.of(new User()));
         when(drinkRepository.findById(invalidDrinkId)).thenReturn(Optional.empty());
@@ -106,17 +95,12 @@ public class OrderServiceImplTest {
 
     @Test
     public void testCreateOrder_InvalidMachineId_ThrowsResourceNotFoundException() {
-        // Arrange
-        Long invalidMachineId = 999L;
-
         OrderRequestDTO orderRequest = new OrderRequestDTO();
         orderRequest.setUserId(1L);
         orderRequest.setDrinkId(2L);
-        orderRequest.setMachineId(invalidMachineId);
 
         when(userRepository.findById(anyLong())).thenReturn(Optional.of(new User()));
         when(drinkRepository.findById(anyLong())).thenReturn(Optional.of(new Drink()));
-        when(machineRepository.findById(invalidMachineId)).thenReturn(Optional.empty());
 
         // Act and Assert
         assertThrows(ResourceNotFoundException.class, () -> orderService.createOrder(orderRequest));
@@ -158,51 +142,5 @@ public class OrderServiceImplTest {
 
         // Act and Assert
         assertThrows(ResourceNotFoundException.class, () -> orderService.getOrderByUserId(invalidUserId));
-    }
-
-    @Test
-    public void testCancelOrderById_OrderExists_Success() {
-        // Arrange
-        Long orderId = 1L;
-
-        Order existingOrder = new Order();
-        existingOrder.setId(orderId);
-        existingOrder.setStatus(OrderStatusEnum.CREATED); // Assuming the initial status is PENDING
-
-        when(orderRepository.findById(orderId)).thenReturn(Optional.of(existingOrder));
-
-        // Act
-        OrderResponseDTO canceledOrderResponse = orderService.cancelOrderById(orderId);
-
-        // Assert
-        assertNotNull(canceledOrderResponse);
-        assertEquals(orderId, canceledOrderResponse.getId());
-        assertEquals(OrderStatusEnum.CANCELED, canceledOrderResponse.getStatus());
-    }
-
-    @Test
-    public void testCancelOrderById_OrderNotFound_ThrowsResourceNotFoundException() {
-        // Arrange
-        Long nonExistentOrderId = 999L;
-
-        when(orderRepository.findById(nonExistentOrderId)).thenReturn(Optional.empty());
-
-        // Act and Assert
-        assertThrows(ResourceNotFoundException.class, () -> orderService.cancelOrderById(nonExistentOrderId));
-    }
-
-    @Test
-    public void testCancelOrderById_OrderAlreadyUpdated_ThrowsDataAlreadyUpdatedException() {
-        // Arrange
-        Long orderId = 1L;
-
-        Order existingOrder = new Order();
-        existingOrder.setId(orderId);
-        existingOrder.setStatus(OrderStatusEnum.CANCELED); // Assuming the order is already canceled
-
-        when(orderRepository.findById(orderId)).thenReturn(Optional.of(existingOrder));
-
-        // Act and Assert
-        assertThrows(DataAlreadyUpdatedException.class, () -> orderService.cancelOrderById(orderId));
     }
 }


### PR DESCRIPTION
Background: After completion, the order status will be changed from `CREATED` to `PENDING`
![image](https://github.com/UWDrinkMaster/drinkmaster-api/assets/44660072/667639cd-739d-45f7-8eb0-9e42bfe78e4e)


1. If a success message was sent by embedded, the order status will be set to `COMPLETED` 
![image](https://github.com/UWDrinkMaster/drinkmaster-api/assets/44660072/a23b41f4-e613-43e2-bb1f-ef1d44acd7b3)

2. If a fail message was sent by embedded, the order status will be set to `CANCELED` 
![image](https://github.com/UWDrinkMaster/drinkmaster-api/assets/44660072/c0f3b524-6bde-4610-860d-743872e52629)

3. The updated order is sent to front end with web socket `/topic/order-complete`         
```
OrderResponseDTO responseDTO = new OrderResponseDTO(updatedOrder);
messagingTemplate.convertAndSend("/topic/order-complete", responseDTO);
```